### PR TITLE
remove the inactive indicators from the carousel

### DIFF
--- a/sportify-project/src/index.css
+++ b/sportify-project/src/index.css
@@ -31,3 +31,15 @@ img {
 .carousel-control-prev-icon {
   visibility: hidden !important;
 }
+
+.carousel-indicators {
+  visibility: hidden !important;
+}
+
+.carousel-control-prev {
+  visibility: hidden !important;
+}
+
+.carousel-control-next {
+  visibility: hidden !important;
+}


### PR DESCRIPTION
There were bootstrap layers over the carousel that rendered the links on the event card unclickable on desktop view.  This removes those layers.  